### PR TITLE
Fix jwk_convert script enc function.

### DIFF
--- a/security/jwk_convert.py
+++ b/security/jwk_convert.py
@@ -14,28 +14,34 @@ import sys
 import json
 import base64
 import binascii
+
+if sys.version_info.major == 2:
+    from __future__ import print_function
+
 with open(sys.argv[1]) as fp:
     PKEY = json.load(fp)
 
 
 def enc(data):
+    if isinstance(data, str):
+        data = data.encode()
     missing_padding = 4 - len(data) % 4
     if missing_padding:
         data += b'=' * missing_padding
+    return b'0x' + binascii.hexlify(base64.b64decode(data, b'-_')).upper()
 
-    return '0x'+binascii.hexlify(base64.b64decode(data, b'-_')).upper()
 
 for k, v in PKEY.items():
     if k == 'kty':
         continue
     PKEY[k] = enc(v.encode())
 
-print "asn1=SEQUENCE:private_key\n[private_key]\nversion=INTEGER:0"
-print "n=INTEGER:{}".format(PKEY[u'n'])
-print "e=INTEGER:{}".format(PKEY[u'e'])
-print "d=INTEGER:{}".format(PKEY[u'd'])
-print "p=INTEGER:{}".format(PKEY[u'p'])
-print "q=INTEGER:{}".format(PKEY[u'q'])
-print "dp=INTEGER:{}".format(PKEY[u'dp'])
-print "dq=INTEGER:{}".format(PKEY[u'dq'])
-print "qi=INTEGER:{}".format(PKEY[u'qi'])
+print("asn1=SEQUENCE:private_key\n[private_key]\nversion=INTEGER:0")
+print("n=INTEGER:{}".format(PKEY[u'n']))
+print("e=INTEGER:{}".format(PKEY[u'e']))
+print("d=INTEGER:{}".format(PKEY[u'd']))
+print("p=INTEGER:{}".format(PKEY[u'p']))
+print("q=INTEGER:{}".format(PKEY[u'q']))
+print("dp=INTEGER:{}".format(PKEY[u'dp']))
+print("dq=INTEGER:{}".format(PKEY[u'dq']))
+print("qi=INTEGER:{}".format(PKEY[u'qi']))


### PR DESCRIPTION
- Checked if data was string and set it back to bytes because if missing_data then an error will happen due to a concatanation of bytes and string.

- Another bytes to string concatenation attempt will happen during the function return statement, that was fixed also.

At the beginning of the script the print_fucntion from future was imported if python version is 2.x. All prints in the end were outputing tuples, and that would be a problem. Used the print as function syntax instead.

Fixes: #13