### PR TITLE
Add Snaplert to visual change monitoring

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -11,7 +11,7 @@
 
 - DNS resource records ([dns-watch.sh](/monitoring/dns-watch.sh), [dnsspy.io](https://dnsspy.io/))
 - HTTP message body (aka HTML source code)
-- Visual change ([visualping.io](https://visualping.io/))
+- Visual change ([visualping.io](https://visualping.io/), [snaplert.com](https://snaplert.com/) — pixel diffs, AI summaries, element-level zone picker)
 - HTTPS certificate and SSL settings ([ssl-check.sh](/monitoring/ssl-check.sh), [ssllabs.com](https://www.ssllabs.com/ssltest/), [Cryptosense](https://discovery.cryptosense.com/))
 - File changes ([tripwire-fake.sh](/monitoring/tripwire-fake.sh))
 - Application log ([laravel-report.sh](https://github.com/szepeviktor/running-laravel/blob/master/bin/laravel-report.sh))


### PR DESCRIPTION
[Snaplert](https://snaplert.com) is a hosted website change monitoring tool that extends the current VisualPing entry with additional capabilities relevant to per-website monitoring:

- **Visual pixel diffs** with before/after screenshots stored per alert
- **AI-powered summaries** (Claude) explain what changed in plain English
- **Element-level zone picker** — monitor specific sections of a page rather than the whole URL
- **5-minute check intervals** with email alerts and webhooks
- **Free during open beta**

Added alongside `visualping.io` in the "Visual change" bullet of the per-website monitoring section.